### PR TITLE
convert eval from python2 to 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*pyc
+model/*
+data/*
+logs_spider_editsql/*
+processed_data_spider_removefrom/*

--- a/eval_scripts/evaluation.py
+++ b/eval_scripts/evaluation.py
@@ -445,33 +445,33 @@ def print_scores(scores, etype):
     partial_types = ['select', 'select(no AGG)', 'where', 'where(no OP)', 'group(no Having)',
                      'group', 'order', 'and/or', 'IUEN', 'keywords']
 
-    print "{:20} {:20} {:20} {:20} {:20} {:20}".format("", *levels)
+    print("{:20} {:20} {:20} {:20} {:20} {:20}".format("", *levels))
     counts = [scores[level]['count'] for level in levels]
-    print "{:20} {:<20d} {:<20d} {:<20d} {:<20d} {:<20d}".format("count", *counts)
+    print("{:20} {:<20d} {:<20d} {:<20d} {:<20d} {:<20d}".format("count", *counts))
 
     if etype in ["all", "exec"]:
-        print '=====================   EXECUTION ACCURACY     ====================='
+        print('=====================   EXECUTION ACCURACY     =====================')
         this_scores = [scores[level]['exec'] for level in levels]
-        print "{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format("execution", *this_scores)
+        print("{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format("execution", *this_scores))
 
     if etype in ["all", "match"]:
-        print '\n====================== EXACT MATCHING ACCURACY ====================='
+        print('\n====================== EXACT MATCHING ACCURACY =====================')
         exact_scores = [scores[level]['exact'] for level in levels]
-        print "{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format("exact match", *exact_scores)
-        print '\n---------------------PARTIAL MATCHING ACCURACY----------------------'
+        print("{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format("exact match", *exact_scores))
+        print('\n---------------------PARTIAL MATCHING ACCURACY----------------------')
         for type_ in partial_types:
             this_scores = [scores[level]['partial'][type_]['acc'] for level in levels]
-            print "{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format(type_, *this_scores)
+            print("{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format(type_, *this_scores))
 
-        print '---------------------- PARTIAL MATCHING RECALL ----------------------'
+        print('---------------------- PARTIAL MATCHING RECALL ----------------------')
         for type_ in partial_types:
             this_scores = [scores[level]['partial'][type_]['rec'] for level in levels]
-            print "{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format(type_, *this_scores)
+            print("{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format(type_, *this_scores))
 
-        print '---------------------- PARTIAL MATCHING F1 --------------------------'
+        print('---------------------- PARTIAL MATCHING F1 --------------------------')
         for type_ in partial_types:
             this_scores = [scores[level]['partial'][type_]['f1'] for level in levels]
-            print "{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format(type_, *this_scores)
+            print("{:20} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f} {:<20.3f}".format(type_, *this_scores))
 
 
 def evaluate(gold, predict, db_dir, etype, kmaps):

--- a/eval_scripts/process_sql.py
+++ b/eval_scripts/process_sql.py
@@ -64,7 +64,7 @@ class Schema:
     def _map(self, schema):
         idMap = {'*': "__all__"}
         id = 1
-        for key, vals in schema.iteritems():
+        for key, vals in schema.items():
             for val in vals:
                 idMap[key.lower() + "." + val.lower()] = "__" + key.lower() + "." + val.lower() + "__"
                 id += 1

--- a/postprocess_eval.py
+++ b/postprocess_eval.py
@@ -417,7 +417,7 @@ def write_and_evaluate(postprocess_sqls, db_path, table_schema_path, gold_path, 
         for postprocess_sql, interaction_id, turn_id in postprocess_sqls[db]:
           f.write(postprocess_sql+'\n')
 
-    command = 'python2 eval_scripts/evaluation.py --db {} --table {} --etype match --gold {} --pred {}'.format(db_path,
+    command = 'python3 eval_scripts/evaluation.py --db {} --table {} --etype match --gold {} --pred {}'.format(db_path,
                                                                                                   table_schema_path,
                                                                                                   gold_path,
                                                                                                   os.path.abspath(output_file))


### PR DESCRIPTION
This commit converts the evaluation script from Python2 to Python3. It involves fixes in `print` statements and a change from `dict.iteritems()` to `dict.items()`. It was tested with [Spider](https://yale-lily.github.io/spider). 